### PR TITLE
Update Scala to 3.3.3

### DIFF
--- a/Early Returns/Baby Steps/build.sbt
+++ b/Early Returns/Baby Steps/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Early Returns/Lazy Collection to the Rescue/build.sbt
+++ b/Early Returns/Lazy Collection to the Rescue/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Early Returns/The Problem/build.sbt
+++ b/Early Returns/The Problem/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Early Returns/Unapply/build.sbt
+++ b/Early Returns/Unapply/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Expressions over Statements/Nested Methods/build.sbt
+++ b/Expressions over Statements/Nested Methods/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Expressions over Statements/Pure vs Impure Functions/build.sbt
+++ b/Expressions over Statements/Pure vs Impure Functions/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Expressions over Statements/Recursion/build.sbt
+++ b/Expressions over Statements/Recursion/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Expressions over Statements/Tail Recursion/build.sbt
+++ b/Expressions over Statements/Tail Recursion/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Expressions over Statements/Using Clause for Carrying an Immutable Context/build.sbt
+++ b/Expressions over Statements/Using Clause for Carrying an Immutable Context/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Expressions over Statements/What is an Expression/build.sbt
+++ b/Expressions over Statements/What is an Expression/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Functions as Data/anonymous_functions/build.sbt
+++ b/Functions as Data/anonymous_functions/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Functions as Data/filter/build.sbt
+++ b/Functions as Data/filter/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Functions as Data/find/build.sbt
+++ b/Functions as Data/find/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Functions as Data/flatMap/build.sbt
+++ b/Functions as Data/flatMap/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Functions as Data/foldLeft/build.sbt
+++ b/Functions as Data/foldLeft/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Functions as Data/foreach/build.sbt
+++ b/Functions as Data/foreach/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Functions as Data/functions_returning_functions/build.sbt
+++ b/Functions as Data/functions_returning_functions/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Functions as Data/map/build.sbt
+++ b/Functions as Data/map/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Functions as Data/partial_fucntion_application/build.sbt
+++ b/Functions as Data/partial_fucntion_application/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Functions as Data/passing_functions_as_arguments/build.sbt
+++ b/Functions as Data/passing_functions_as_arguments/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Functions as Data/scala_collections_overview/build.sbt
+++ b/Functions as Data/scala_collections_overview/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Functions as Data/scala_collections_overview/task-info.yaml
+++ b/Functions as Data/scala_collections_overview/task-info.yaml
@@ -1,9 +1,9 @@
 type: edu
 custom_name: Scala Collections Overview
 files:
-- name: test/TestSpec.scala
-  visible: false
-- name: build.sbt
-  visible: false
-- name: src/Task.scala
-  visible: true
+  - name: test/TestSpec.scala
+    visible: false
+  - name: build.sbt
+    visible: false
+  - name: src/Task.scala
+    visible: true

--- a/Functions as Data/scala_collections_overview/task-info.yaml
+++ b/Functions as Data/scala_collections_overview/task-info.yaml
@@ -1,9 +1,9 @@
 type: edu
 custom_name: Scala Collections Overview
 files:
-  - name: test/TestSpec.scala
-    visible: false
-  - name: build.sbt
-    visible: false
-  - name: src/Task.scala
-    visible: true
+- name: test/TestSpec.scala
+  visible: false
+- name: build.sbt
+  visible: false
+- name: src/Task.scala
+  visible: true

--- a/Functions as Data/total_and_partial_functions/build.sbt
+++ b/Functions as Data/total_and_partial_functions/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Functions as Data/what_is_a_function/build.sbt
+++ b/Functions as Data/what_is_a_function/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Immutability/A View/build.sbt
+++ b/Immutability/A View/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Immutability/Berliner Pattern/build.sbt
+++ b/Immutability/Berliner Pattern/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Immutability/Case Class Copy/build.sbt
+++ b/Immutability/Case Class Copy/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Immutability/Comparison of View and Lazy Collection/build.sbt
+++ b/Immutability/Comparison of View and Lazy Collection/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Immutability/Lazy List/build.sbt
+++ b/Immutability/Lazy List/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Immutability/Lazy Val/build.sbt
+++ b/Immutability/Lazy Val/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Immutability/Scala Collections instead of Imperative Loops/build.sbt
+++ b/Immutability/Scala Collections instead of Imperative Loops/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Immutability/The Builder Pattern/build.sbt
+++ b/Immutability/The Builder Pattern/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Monads/Either as an Alternative to Exceptions/build.sbt
+++ b/Monads/Either as an Alternative to Exceptions/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Monads/Monadic Laws/build.sbt
+++ b/Monads/Monadic Laws/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Monads/Non-Determinism with Lists/build.sbt
+++ b/Monads/Non-Determinism with Lists/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Monads/Option as an Alternative to null/build.sbt
+++ b/Monads/Option as an Alternative to null/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Monads/Syntactic Sugar and For-Comprehensions/build.sbt
+++ b/Monads/Syntactic Sugar and For-Comprehensions/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Monads/Use Try Instead of try-catch/build.sbt
+++ b/Monads/Use Try Instead of try-catch/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Pattern Matching/A Custom unapply Method/build.sbt
+++ b/Pattern Matching/A Custom unapply Method/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Pattern Matching/Case Class/build.sbt
+++ b/Pattern Matching/Case Class/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Pattern Matching/Case Objects/build.sbt
+++ b/Pattern Matching/Case Objects/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Pattern Matching/Case Objects/task-info.yaml
+++ b/Pattern Matching/Case Objects/task-info.yaml
@@ -1,5 +1,5 @@
 type: edu
-custom_name: 'Case Objects'
+custom_name: Case Objects
 files:
   - name: src/CaseObjectTask.scala
     visible: true

--- a/Pattern Matching/Destructuring/build.sbt
+++ b/Pattern Matching/Destructuring/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Pattern Matching/Enums/build.sbt
+++ b/Pattern Matching/Enums/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Pattern Matching/Pattern Matching/build.sbt
+++ b/Pattern Matching/Pattern Matching/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Pattern Matching/Sealed Traits Hierarchies/build.sbt
+++ b/Pattern Matching/Sealed Traits Hierarchies/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Pattern Matching/Smart Constructors and the apply Method/build.sbt
+++ b/Pattern Matching/Smart Constructors and the apply Method/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/Pattern Matching/The Newtype Pattern/build.sbt
+++ b/Pattern Matching/The Newtype Pattern/build.sbt
@@ -1,4 +1,4 @@
 scalaSource in Compile := baseDirectory.value / "src"
 scalaSource in Test := baseDirectory.value / "test"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"

--- a/build.sbt
+++ b/build.sbt
@@ -17,4 +17,4 @@ def isTaskDir(dir: File): Boolean = new File(dir, "src").exists()
 def isNotIgnored(dir: File): Boolean = !Seq(".idea", ".coursecreator", "project", "target").contains(dir.getName)
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15"
-scalaVersion := "3.2.0"
+scalaVersion := "3.3.3"


### PR DESCRIPTION
This is just for consistency. Scala 3.3 has Long Term Support guaranteed by the compiler team and it's the default Scala 3 version used by IntelliJ Scala Plugin.